### PR TITLE
Change default WS port to 8080

### DIFF
--- a/plugins/WebSocketDataSender/WebSocketDataGetter.cs
+++ b/plugins/WebSocketDataSender/WebSocketDataGetter.cs
@@ -24,7 +24,7 @@ namespace WebSocketDataSender
         public string SettingGroup { get; } = "Output patterns";
 
         public static ConfigEntry Enabled = new ConfigEntry("webSocketEnabled", false);
-        public static ConfigEntry WebSocketPort = new ConfigEntry("webSocketPort", 80);
+        public static ConfigEntry WebSocketPort = new ConfigEntry("webSocketPort", 8080);
         public static ConfigEntry WebSocketAddress = new ConfigEntry("webSocketAddress", "127.0.0.1");
 
         private DataContainer _liveDataContainer = new DataContainer();


### PR DESCRIPTION
On Linux systems, it is not possible to bind to a port lower than 1024 without being root, and running Wine under superuser permissions is really insecure.

This changes the default port to something possible to run without root.