### PR TITLE
Process.Start in-line with DotNet 5.0

### DIFF
--- a/plugins/LiveVisualizer/LiveVisualizerSettings.cs
+++ b/plugins/LiveVisualizer/LiveVisualizerSettings.cs
@@ -172,12 +172,12 @@ namespace LiveVisualizer
 
         private void linkLabel_UICredit1_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start("https://osu.ppy.sh/users/9173653");
+            Process.Start("explorer.exe", "https://osu.ppy.sh/users/9173653");
         }
 
         private void linkLabel_UICredit2_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start("https://osu.ppy.sh/users/4944211");
+            Process.Start("explorer.exe", "https://osu.ppy.sh/users/4944211");
         }
 
         private void Button_miniCounter_Click(object sender, EventArgs e)


### PR DESCRIPTION
netcore 5.0 broke support for opening links with one argument. Current state throws 
![image](https://user-images.githubusercontent.com/20248967/112202199-eb5e2080-8c32-11eb-8917-8c5c79a541b0.png)
