### PR TITLE
Fix: Round of mStars token on web overlays

### DIFF
--- a/webOverlay/overlays/SC_Live Overlay/index.html
+++ b/webOverlay/overlays/SC_Live Overlay/index.html
@@ -28,7 +28,7 @@
         <div class="flexSpacer flexEnd" style="width: 100%">
           <div class="flexSpacer flexEnd" style="width: 100%; position: absolute">
             <div class="mapStats" :class="{hide: overlaySettings.hideMapStats}">
-              <div><strong>SR</strong>{{getToken('mStars')}}</div>
+              <div><strong>SR</strong>{{getToken('mStars', 2)}}</div>
               <div><strong>CS</strong>{{getToken('mCS')}}</div>
               <div><strong>AR</strong>{{getToken('mAR')}}</div>
               <div><strong>OD</strong>{{getToken('mOD')}}</div>

--- a/webOverlay/overlays/SC_Map Example/index.html
+++ b/webOverlay/overlays/SC_Map Example/index.html
@@ -47,7 +47,7 @@
                 <strong>{{getToken('mOD')}}</strong>
             </p>
             <p class="outer-right star">
-                Star Rating <strong>{{getToken('mStars')}}</strong>
+                Star Rating <strong>{{getToken('mStars', 2)}}</strong>
             </p>
         </div>
     </div>


### PR DESCRIPTION
This fixes that mStar have too long on SC_Live Overlay and SC_Map Example.
Before:
![image](https://user-images.githubusercontent.com/37479424/125227385-c8549b00-e30d-11eb-9b7c-fd3cb8d1935a.png)
After:
![image](https://user-images.githubusercontent.com/37479424/125227408-d1456c80-e30d-11eb-9874-73c2e9d8731a.png)
