### PR TITLE
Add: Support instructing browsers to cache backgroundImage.

### DIFF
--- a/docs/docs/development/SC/api.md
+++ b/docs/docs/development/SC/api.md
@@ -50,6 +50,12 @@ Current map background image
 * Base url with no parameters returns map image file as-is without any processing.
 * setting `width` or `height` query parameters ensures that at least one of these will be matched while preserving original image aspect ratio. [check it out](http://localhost:20727/backgroundImage?width=500&height=500)
   * in addition, setting `crop=1` disregards image aspect ratio and returns cropped image with specified dimensions, resizing it beforehand if necessary. [check it out](http://localhost:20727/backgroundImage?width=500&height=500&crop=1)
+* Add `cache=true` to query parameters, and SC will set the [**Cache-Control**](https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control) response header to instruct the browser to cache background images. When images are repeatedly loaded, it will save a lot of loading time.
+  * When using caching, it is necessary to add some query parameters to distinguish requests. If no other parameters are added, it will cause the browser to always use the background image of the first beatmap instead of refreshing it to the background image of other beatmap. For example, you can set the Id of the current Beatmap to the query parameters: 
+    
+    ```
+    /backgroundImage?cache=true&mapId=123456
+    ```
 
 ### [`Songs`](http://localhost:20727/Songs)
 

--- a/docs/docs/development/SC/api.md
+++ b/docs/docs/development/SC/api.md
@@ -49,13 +49,13 @@ Current map background image
 
 * Base url with no parameters returns map image file as-is without any processing.
 * setting `width` or `height` query parameters ensures that at least one of these will be matched while preserving original image aspect ratio. [check it out](http://localhost:20727/backgroundImage?width=500&height=500)
-  * in addition, setting `crop=1` disregards image aspect ratio and returns cropped image with specified dimensions, resizing it beforehand if necessary. [check it out](http://localhost:20727/backgroundImage?width=500&height=500&crop=1)
-* Add `cache=true` to query parameters, and SC will set the [**Cache-Control**](https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control) response header to instruct the browser to cache background images. When images are repeatedly loaded, it will save a lot of loading time.
-  * When using caching, it is necessary to add some query parameters to distinguish requests. If no other parameters are added, it will cause the browser to always use the background image of the first beatmap instead of refreshing it to the background image of other beatmap. For example, you can set the Id of the current Beatmap to the query parameters: 
-    
-    ```
-    /backgroundImage?cache=true&mapId=123456
-    ```
+  * in addition, setting `crop=true` disregards image aspect ratio and returns cropped image with specified dimensions, resizing it beforehand if necessary. [check it out](http://localhost:20727/backgroundImage?width=500&height=500&crop=true)
+* Set `cache=true` and SC will set the [**Cache-Control**](https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control) response header to instruct the browser to cache background images. When images are repeatedly loaded, it will save a lot of loading time.
+  ::: tip cache usage
+  When using caching, it is necessary to add some query parameters to distinguish requests. If no other parameters are added, it will result in your browser always reusing the background image of the first loaded map. For example, you can use Id of the current map to create unique urls:
+
+  `/backgroundImage?cache=true&mapId=123456`
+  :::
 
 ### [`Songs`](http://localhost:20727/Songs)
 

--- a/plugins/WebSocketDataSender/WebSocketDataGetter.cs
+++ b/plugins/WebSocketDataSender/WebSocketDataGetter.cs
@@ -165,6 +165,10 @@ namespace WebSocketDataSender
                 if (!File.Exists(location))
                     return;
 
+                bool.TryParse(context.Request.QueryString.Get("cache"), out var enableCache);
+                if (enableCache)
+                    context.Response.Headers.Add("Cache-Control", "public, max-age=7200");
+
                 await using var fs = new FileStream(location, FileMode.Open, FileAccess.Read);
                 if (!(context.Request.QueryString.ContainsKey("width") ||
                     context.Request.QueryString.ContainsKey("height")))


### PR DESCRIPTION
This Pull Request adds a `Cache-Control` response header to the `/backgroundImage` endpoint in WebSocketDataSender plugin.

By instructing the browser to cache background images, it can significantly improve the loading speed of previously loaded Beatmap background images reloading in the browser page.

![image](https://github.com/Piotrekol/StreamCompanion/assets/16975255/87a968de-58a6-4875-93e1-90e271e3c442)

It should be noted that by default, the `Cache-Control` response header will not be added, and the requester must attach the query string `cache=true` in order for the plugin to add cache instructions to the response. (This is to ensure compatibility)

The recommended approach is to use it in conjunction with a "meaningless" query string that identifies the background image, like this:

```
http://localhost:20727/backgroundImage?cache=true&mapid=668662
```

The `mapid` will not be processed by the plugin, but it can allow the browser to uniquely identify the background image and cache it for use during the next load.
