### PR TITLE
Feat: Support obtaining specified data in a low resource consumption manner by specifying the required token.

### DIFF
--- a/docs/docs/development/SC/api.md
+++ b/docs/docs/development/SC/api.md
@@ -37,6 +37,14 @@ All tokens available in StreamCompanion in form of json object.
 ::: tip
 This endpoint should be used only as a tokens reference. Use these via [tokens](#tokens) WebSocket endpoint in actual implementations.  
 **Ignoring this will result in unnecessary resource usage**, as live token values are computed only when used.
+
+If you want to obtain tokens at a lower frequency, you can set multiple `token` query strings to indicate the desired token, like this:
+
+`/json?token=ar&token=cs&token=od&token=hp`
+
+This will only obtain four tokens for AR, CS, OD and HP.
+
+After indicating the required tokens, SC will not serialize all tokens, thereby minimizing resource usage (mainly serialization).
 :::
 
 ::: details Example output

--- a/plugins/WebSocketDataSender/WebSocketDataGetter.cs
+++ b/plugins/WebSocketDataSender/WebSocketDataGetter.cs
@@ -149,7 +149,18 @@ namespace WebSocketDataSender
                 return context.SendStringAsync(JsonConvert.SerializeObject(Tokens.AllTokens), "application/json", Encoding.UTF8);
             }
 
-            return context.SendStringAsync(JsonConvert.SerializeObject(Tokens.AllTokens.ToDictionary(k => k.Key, v => v.Value.Value)), "application/json", Encoding.UTF8);
+            Dictionary<string, object> tokens = null;
+            if (context.Request.QueryString.ContainsKey("token"))
+            {
+                HashSet<string> selectedTokens =context.Request.QueryString.GetValues("token").ToHashSet();
+                tokens = Tokens.AllTokens.Where((token) => { return selectedTokens.Contains(token.Key); }).ToDictionary(k => k.Key, v => v.Value.Value);
+            } 
+            else
+            {
+                tokens = Tokens.AllTokens.ToDictionary(k => k.Key, v => v.Value.Value);
+            }
+
+            return context.SendStringAsync(JsonConvert.SerializeObject(tokens), "application/json", Encoding.UTF8);
         }
 
         private async Task SendCurrentBeatmapImage(IHttpContext context)


### PR DESCRIPTION
This change allows users to request `/json` endpoints by specifying one or more token query fields, allowing SC to return a small amount of data and obtain data at a low frequency with lower resource usage.

I originally intended to use this method to obtain time at low frequencies for more accurate PlayStatus judgment, but it did not work. But this change looks good.